### PR TITLE
Fix Clarity initialization

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { Poppins } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import { UserProvider } from "@/contexts/user-context";
-import Clarity from '@microsoft/clarity';
+import ClarityProvider from '@/components/clarity';
 const poppinsSans = Poppins({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
@@ -21,9 +21,6 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const projectId = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID;
-  if(projectId){
-    Clarity.init(projectId);
-  }
   
   return (
     <html lang="pt-br">
@@ -34,7 +31,9 @@ export default function RootLayout({
           {children}
         </UserProvider>
         <Toaster />
+        {projectId && <ClarityProvider projectId={projectId} />}
       </body>
     </html>
   );
 }
+

--- a/components/clarity.tsx
+++ b/components/clarity.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useEffect } from 'react'
+import Clarity from '@microsoft/clarity'
+
+interface ClarityProps {
+  projectId: string
+}
+
+export default function ClarityProvider({ projectId }: ClarityProps) {
+  useEffect(() => {
+    if (projectId) {
+      Clarity.init(projectId)
+    }
+  }, [projectId])
+  return null
+}
+


### PR DESCRIPTION
## Summary
- avoid running `@microsoft/clarity` on the server

## Testing
- `npm run build` *(fails: Failed to fetch font `Poppins`)*

------
https://chatgpt.com/codex/tasks/task_e_6840327fc164832e99af180bd4719d72